### PR TITLE
Fixing glob pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,10 @@ repos:
     rev: 2.1.5  # or specific git tag
     hooks:
       - id: shellcheck
-        # args:
-        #   - "-e"
-        #   - "SC1090"
+        args:
+          - "-e"
+          - "SC2035"
+        # - "-e"
+        # - "SC1090"
         #   - "-e"
         #   - "SC1091"

--- a/dry-run.sh
+++ b/dry-run.sh
@@ -5,6 +5,6 @@ find . -type d -not -path '**/\.*' -path "./${DOC_DIR_PATTERN}" |
     while read -r doc_dir; do
         echo "==> Verify markdown files into ${doc_dir}"
         pushd "${doc_dir}"
-        grep -R -l 'Space:' "*.md" | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug --dry-run -f {} > /dev/null
+        grep -R -l 'Space:' *.md | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug --dry-run -f {} > /dev/null
         popd
     done

--- a/publish.sh
+++ b/publish.sh
@@ -5,6 +5,6 @@ find . -type d -not -path '**/\.*' -path "./${DOC_DIR_PATTERN}" |
     while read -r doc_dir; do
         echo "==> Upload markdown files into ${doc_dir}"
         pushd "${doc_dir}"
-        grep -R -l 'Space:' "*.md" | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug -f {} > /dev/null
+        grep -R -l 'Space:' *.md | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug -f {} > /dev/null
         popd
     done

--- a/verify.sh
+++ b/verify.sh
@@ -5,6 +5,6 @@ find . -type d -not -path '**/\.*' -path "./${DOC_DIR_PATTERN}" |
     while read -r doc_dir; do
         echo "==> Verify markdown files into ${doc_dir}"
         pushd "${doc_dir}"
-        grep -R -l 'Space:' "*.md" | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug --compile-only -f {} > /dev/null
+        grep -R -l 'Space:' *.md | xargs -n1 -I{} mark -p "${CONFLUENCE_PASSWORD}" -u "${CONFLUENCE_USERNAME}" -b "${BASE_URL}" --debug --compile-only -f {} > /dev/null
         popd
     done


### PR DESCRIPTION
- Fixing glob pattern for `grep` and avoid error from shellcheck